### PR TITLE
fixed scrolling behavior push-in menu 1047

### DIFF
--- a/css/menu.css
+++ b/css/menu.css
@@ -23,11 +23,6 @@ body.has-menu-left.has-push-menu {
   overflow: hidden;
 }
 
-html.no-android body.has-push-menu,
-html.no-android.has-push-menu {
-  -webkit-overflow-scrolling: auto;
-}
-
 .fl-with-top-menu {
   -webkit-transition: padding 0.2s;
   transition: padding 0.2s;

--- a/css/menu.css
+++ b/css/menu.css
@@ -26,7 +26,6 @@ body.has-menu-left.has-push-menu {
 html.no-android body.has-push-menu,
 html.no-android.has-push-menu {
   -webkit-overflow-scrolling: auto;
-  overflow-y: hidden;
 }
 
 .fl-with-top-menu {

--- a/css/menu.css
+++ b/css/menu.css
@@ -26,7 +26,7 @@ body.has-menu-left.has-push-menu {
 html.no-android body.has-push-menu,
 html.no-android.has-push-menu {
   -webkit-overflow-scrolling: auto;
-  overflow: visible;
+  overflow-y: hidden;
 }
 
 .fl-with-top-menu {


### PR DESCRIPTION
@squallstar @tonytlwu 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/1047
## Description
Changed scroll behavior to prevent scrolling background.
## Screenshots/screencasts
![push-in-menu](https://user-images.githubusercontent.com/52824216/64010202-f964c180-cb21-11e9-8006-48bf9337a4d6.gif)
## Backward compatibility
This change is fully backward compatible.