### PR TITLE
Fixes drop area

### DIFF
--- a/css/menu.css
+++ b/css/menu.css
@@ -35,7 +35,7 @@ html.android .fl-with-top-menu main.fl-page-content-wrapper {
   min-height: calc(100vh - 44px);
 }
 
-html.web[data-has-notch].supports-container .fl-with-top-menu {
+[data-has-notch].supports-container .fl-with-top-menu {
   padding-bottom: 0;
 }
 

--- a/css/menu.css
+++ b/css/menu.css
@@ -29,6 +29,16 @@ body.has-menu-left.has-push-menu {
   padding-top: 44px;
 }
 
+html.web .fl-with-top-menu main.fl-page-content-wrapper,
+html.android .fl-with-top-menu main.fl-page-content-wrapper {
+  /* Remove the height of the menu */
+  min-height: calc(100vh - 44px);
+}
+
+html.web[data-has-notch].supports-container .fl-with-top-menu {
+  padding-bottom: 0;
+}
+
 [data-fl-widget-instance][data-type="menu"] {
   position: fixed !important;
   top: 0;


### PR DESCRIPTION
- We remove `body`'s bottom padding on `[data-has-notch]` devices in Edit, for apps with container support
- We remove the menu height from the drop area height when using `100vh` [web , android]