### PR TITLE
PS-1966: Preserve exit-app (and other non-screen) items in master-page DOM cleanup

### DIFF
--- a/js/menu.js
+++ b/js/menu.js
@@ -33,7 +33,8 @@ function init() {
         return;
       }
 
-      // Preserve logout items whose target screen happens to be a master page (PS-1939)
+      // Cleanup only applies to items that actually navigate to that pageId as a screen view.
+      // Skip non-screen actions whose pageId is incidental (PS-1939, PS-1966)
       var nav = {};
 
       try {
@@ -42,7 +43,9 @@ function init() {
         // Malformed JSON — fall through and remove
       }
 
-      if (nav.action === 'logout') {
+      var nonScreenActions = ['logout', 'exit-app', 'url', 'popup', 'about-overlay'];
+
+      if (nonScreenActions.indexOf(nav.action) !== -1) {
         return;
       }
 


### PR DESCRIPTION
## Summary
- The PS-1810 cleanup pass in `js/menu.js` removes menu items whose `data-page-id` matches a master page ID. PS-1939 added a `logout`-only exception, but the same root cause affects every menu item whose action does not navigate to that pageId as a screen view.
- For Fox Williams (PS-1966), the customer's "Portal" item with `action: exit-app` was being stripped because its pageId happens to match a masterPageId in the production app, then the menu's `addExitAppMenuLink` hook re-appended an "Exit" item — replacing "Portal" with "Exit" in the rendered menu.
- Broaden the exception list so the cleanup runs only against items that actually resolve to a master-page screen view. The current allowlist is `['logout', 'exit-app', 'url', 'popup', 'about-overlay']`.

## Test plan
- [ ] Reopen any FW sub-portal app using the Push-in menu and confirm the Portal menu item is rendered (not replaced by Exit).
- [ ] Regression: Log Out item targeting a master page must still render (PS-1939 behaviour).
- [ ] Regression: A regular screen menu item that targets a master page must still be removed by the cleanup.
- [ ] Regression: A sub-portal app with no "Portal" menu item should still get the auto-injected "Exit" from the `addExitAppMenuLink` hook.
- [ ] Malformed `data-fl-navigate` JSON still falls through to remove.

Linked: PS-1810 (regression source), PS-1939 (related fix), PS-1966 (this ticket). Companion PRs in fliplet-menu-bottom-bar, fliplet-menu-circle, fliplet-menu-sequential, fliplet-menu-default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)